### PR TITLE
Fix cart counting for lockerMaxItems

### DIFF
--- a/samedaycourier-shipping.php
+++ b/samedaycourier-shipping.php
@@ -99,7 +99,7 @@ function samedaycourier_shipping_method() {
                             continue;
                         }
 
-                        if ($service->sameday_code === "LN" && count(WC()->cart->get_cart()) > $lockerMaxItems) {
+                        if ($service->sameday_code === "LN" && WC()->cart->get_cart_contents_count() > $lockerMaxItems) {
                             continue;
                         }
 


### PR DESCRIPTION
Get the number of cart items including their quantity counts. At the moment it only returns the number of unique products in the cart, disregarding quantities. 